### PR TITLE
Add WP Learn Word to admin sidebar in Persian

### DIFF
--- a/wp-learn-word/includes/class-raswp-admin.php
+++ b/wp-learn-word/includes/class-raswp-admin.php
@@ -14,7 +14,8 @@ class RASWP_Admin {
 			'manage_options',
 			'raswp',
 			[__CLASS__, 'raswp_render_dashboard'],
-			'dashicons-yes-alt'
+			'dashicons-yes-alt',
+			21
 		);
 
 		add_submenu_page('raswp', __('تنظیمات', 'wp-learn-word'), __('تنظیمات', 'wp-learn-word'), 'manage_options', 'raswp-settings', [__CLASS__, 'raswp_render_settings']);


### PR DESCRIPTION
Set the 'WP Learn Word' admin menu to appear below Posts and Pages in the WordPress sidebar.

---
<a href="https://cursor.com/background-agent?bcId=bc-b225dfe1-4c51-4793-ba13-b82b07d962cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b225dfe1-4c51-4793-ba13-b82b07d962cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

