### PR TITLE
Fix plugin admin panel visibility

### DIFF
--- a/wp-learn-word/wp-learn-word.php
+++ b/wp-learn-word/wp-learn-word.php
@@ -51,10 +51,9 @@ function raswp_init_components() {
 }
 add_action('init', 'raswp_init_components');
 
-function raswp_admin_init_components() {
+if (is_admin()) {
 	RASWP_Admin::raswp_register_admin();
 }
-add_action('admin_init', 'raswp_admin_init_components');
 
 function raswp_plugins_loaded() {
 	RASWP_Frontend::raswp_bootstrap_frontend();


### PR DESCRIPTION
Move admin menu registration to ensure the plugin's admin panel appears in wp-admin.

The admin menu was previously registered on the `admin_init` hook, which could sometimes be too late, preventing the menu from being displayed. By moving the registration to execute unconditionally when `is_admin()` is true, the menu is guaranteed to be added before the `admin_menu` hook runs and the sidebar is built.

---
<a href="https://cursor.com/background-agent?bcId=bc-d894b86e-5b23-4dd7-acc5-6c7501fa049e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d894b86e-5b23-4dd7-acc5-6c7501fa049e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

